### PR TITLE
FIX: Remove the client secret from the Keycloak authorization endpoint

### DIFF
--- a/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
+++ b/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
@@ -273,9 +273,6 @@ namespace Keycloak.IdentityModel.Utilities
             if (!string.IsNullOrWhiteSpace(_options.ClientId))
             {
                 parameters.Add(Protocols.OpenIdConnectParameterNames.ClientId, _options.ClientId);
-
-                if (!string.IsNullOrWhiteSpace(_options.ClientSecret))
-                    parameters.Add(Protocols.OpenIdConnectParameterNames.ClientSecret, _options.ClientSecret);
             }
 
             if (!string.IsNullOrWhiteSpace(_options.IdentityProvider))


### PR DESCRIPTION
The fix removes the client secret from the Keycloak Authorization endpoint.
The client secret is not used by the authentication request, and the client secret should not be visible to user in the browser.

Tested on an ASP.NET MVC UI application, with a Keycloak client using Standard (code) Flow and Access-Type: confidential.

I have not verified Implicit flow, I am not sure if this library is expected to support that (?). 

According to the OpenId Connect specification (used by Keycloak), neither Code, Implicit (nor Hybrid) flow expects a client secret in the authentication request (http://openid.net/specs/openid-connect-core-1_0.html)

When running the library in WebApi mode (which only verifies the bearer token), it should not be affected as it does not do an authentication request itself (as per my understanding)

This is my first real pull request on GitHub, please let me know if the way the branch, commit and pull request were done can be improved :)

#3 
