### PR TITLE
Feature/fix token expired at login issue

### DIFF
--- a/src/Keycloak.IdentityModel/KeycloakIdentity.cs
+++ b/src/Keycloak.IdentityModel/KeycloakIdentity.cs
@@ -50,7 +50,7 @@ namespace Keycloak.IdentityModel
 		/// <summary>
 		///     Gets a value that indicates whether the identity has been authenticated
 		/// </summary>
-		public override bool IsAuthenticated => _kcClaims != null && _accessToken.ValidTo > DateTime.Now;
+		public override bool IsAuthenticated => _kcClaims != null && _accessToken.ValidTo > DateTime.UtcNow;
 
 		/// <summary>
 		///     Gets a value that indicates whether the identity has been updated since its instantiation
@@ -420,18 +420,16 @@ namespace Keycloak.IdentityModel
 			await _refreshLock.WaitAsync();
 			try
 			{
-				// Check to update cached claims, but not if refresh token is missing (as in bearer mode)
-				if ((_kcClaims == null || _accessToken.ValidTo <= DateTime.Now) && _refreshToken != null)
-				{
-					var info = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
-					DateTimeOffset localServerTime = DateTimeOffset.Now;
-					DateTimeOffset utc = localServerTime.ToUniversalTime();
-					// Validate refresh token expiration
-					if (_refreshToken.ValidTo <= utc.AddHours(-1))
-						throw new Exception("Both the access token and the refresh token have expired");
-					// Load new identity from token endpoint via refresh token
-					await RefreshIdentity(_refreshToken.RawData);
-				}
+			    // Check to update cached claims, but not if refresh token is missing (as in bearer mode)
+			    if ((_kcClaims == null || _accessToken.ValidTo <= DateTime.UtcNow) && _refreshToken != null)
+			    {
+			        // Validate refresh token expiration
+			        if (_refreshToken.ValidTo <= DateTime.UtcNow)
+			            throw new Exception("Both the access token and the refresh token have expired");
+
+			        // Load new identity from token endpoint via refresh token
+			        await RefreshIdentity(_refreshToken.RawData);
+			    }
 				return GetCurrentClaims();
 			}
 			finally

--- a/src/Keycloak.IdentityModel/KeycloakIdentity.cs
+++ b/src/Keycloak.IdentityModel/KeycloakIdentity.cs
@@ -420,16 +420,16 @@ namespace Keycloak.IdentityModel
 			await _refreshLock.WaitAsync();
 			try
 			{
-			    // Check to update cached claims, but not if refresh token is missing (as in bearer mode)
-			    if ((_kcClaims == null || _accessToken.ValidTo <= DateTime.UtcNow) && _refreshToken != null)
-			    {
-			        // Validate refresh token expiration
-			        if (_refreshToken.ValidTo <= DateTime.UtcNow)
-			            throw new Exception("Both the access token and the refresh token have expired");
+				// Check to update cached claims, but not if refresh token is missing (as in bearer mode)
+				if ((_kcClaims == null || _accessToken.ValidTo <= DateTime.UtcNow) && _refreshToken != null)
+				{
+					// Validate refresh token expiration
+					if (_refreshToken.ValidTo <= DateTime.UtcNow)
+						throw new Exception("Both the access token and the refresh token have expired");
 
-			        // Load new identity from token endpoint via refresh token
-			        await RefreshIdentity(_refreshToken.RawData);
-			    }
+					// Load new identity from token endpoint via refresh token
+					await RefreshIdentity(_refreshToken.RawData);
+				}
 				return GetCurrentClaims();
 			}
 			finally


### PR DESCRIPTION
For MVC applications, after initial login (and subsequent token refreshes) the code below always did an unnecessary refresh token request, because it compared the access token expiration time (UTC) with the local server time (DateTime.Now). Depending on your local time timezone the behavior may differ.

There is a commit in the original repository that makes the same fix
https://github.com/dylanplecki/KeycloakOwinAuthentication/commit/374a5033e62500d3ff1c9ce1a55eb7ef9e63d60f

I made the same change in here: 

- Changed the access token ValidTo comparison to use DateTime.UtcNow instead of DateTime.Now
- Also changed the safety check later on that checks if the refresh token is expired as well by using UTC.
_I didn't understand the original code that subtracts one hour from UTC_  "`if (_refreshToken.ValidTo <= utc.AddHours(-1))`".  I replaced it with "`if (_refreshToken.ValidTo <= DateTime.UtcNow)`" which I assume would be correct.  **@mattmorg55 do you remember why the original code does this**?

An additional change not in the original commit is the public property IsAuthenticated, which I changed similarly.


