### PR TITLE
FIX: Redirect to page when Keycloak authentication fails during login.

### DIFF
--- a/src/Keycloak.IdentityModel/Models/Configuration/DefaultKeycloakParameters.cs
+++ b/src/Keycloak.IdentityModel/Models/Configuration/DefaultKeycloakParameters.cs
@@ -143,5 +143,15 @@ namespace Keycloak.IdentityModel.Models.Configuration
         ///     - Default: false
         /// </remarks>
         public bool DisableRefreshTokenSignatureValidation { get; set; } = false;
+
+
+        /// <summary>
+        ///     OPTIONAL: The absolute or relative URL for users to be redirected to if the authorization response from Keycloak indicated unsuccessful authorization (query parameter "error")
+        /// </summary>
+        /// <remarks>
+        ///     - Default: If not specified, an exception will be thrown if and error from Keycloak authentication is received.
+        /// </remarks>
+        public string AuthResponseErrorRedirectUrl { get; set; }
+
     }
 }

--- a/src/Keycloak.IdentityModel/Models/Configuration/IKeycloakSettings.cs
+++ b/src/Keycloak.IdentityModel/Models/Configuration/IKeycloakSettings.cs
@@ -21,5 +21,7 @@ namespace Keycloak.IdentityModel.Models.Configuration
         string CallbackPath { get; }
         string ResponseType { get; }
         bool DisableRefreshTokenSignatureValidation { get; }
+        string AuthResponseErrorRedirectUrl { get; }
+
     }
 }

--- a/src/Keycloak.IdentityModel/Models/Responses/AuthorizationResponse.cs
+++ b/src/Keycloak.IdentityModel/Models/Responses/AuthorizationResponse.cs
@@ -11,9 +11,12 @@ namespace Keycloak.IdentityModel.Models.Responses
         {
             InitFromRequest(HttpUtility.ParseQueryString(query));
 
-            if (!Validate())
+            if (IsSuccessfulResponse())
             {
-                throw new ArgumentException("Invalid query string used to instantiate an AuthorizationResponse");
+                if (!ValidateCodeAndState())
+                {
+                    throw new ArgumentException("Invalid query string used to instantiate an AuthorizationResponse");
+                }
             }
         }
 
@@ -28,7 +31,7 @@ namespace Keycloak.IdentityModel.Models.Responses
             State = authResult.Get(OpenIdConnectParameterNames.State);
         }
 
-        public bool Validate()
+        public bool ValidateCodeAndState()
         {
             return !string.IsNullOrWhiteSpace(Code) && !string.IsNullOrWhiteSpace(State);
         }

--- a/src/Owin.Security.Keycloak/Configuration/KeycloakAuthenticationOptions.cs
+++ b/src/Owin.Security.Keycloak/Configuration/KeycloakAuthenticationOptions.cs
@@ -203,6 +203,15 @@ namespace Owin.Security.Keycloak
         ///       As the application should not use the contents of the Refresh tokens, only send it back to the Keycloak server (which will validate it), it should be safe to disable it.
         ///     - Default: false
         /// </remarks>
-        public bool DisableRefreshTokenSignatureValidation { get; set; } = false;         
+        public bool DisableRefreshTokenSignatureValidation { get; set; } = false;
+
+        /// <summary>
+        ///     OPTIONAL: The absolute or relative URL for users to be redirected to if the authorization response from Keycloak indicated unsuccessful authorization (query parameter "error")
+        /// </summary>
+        /// <remarks>
+        ///     - Default: If not specified, an exception will be thrown if and error from Keycloak authentication is received.
+        /// </remarks>
+        public string AuthResponseErrorRedirectUrl { get; set; }
+
     }
 }

--- a/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
+++ b/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IdentityModel;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Security.Authentication;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -62,6 +63,14 @@ namespace Owin.Security.Keycloak.Middleware
             {
                 // Create authorization result from query
                 var authResult = new AuthorizationResponse(Request.Uri.Query);
+
+                // If the authorization response returned a "error" query parameter (instead of "code" + "state"), redirect to a configured URL.
+                // This could occur if the login is aborted by the user.
+                if (!authResult.IsSuccessfulResponse())
+                {
+                    HandleAuthError(authResult);
+                    return true;
+                }
 
                 try
                 {
@@ -226,6 +235,51 @@ namespace Owin.Security.Keycloak.Middleware
             response.ReasonPhrase = reasonPhrase;
             response.ContentType = "text/plain";
             await task;
+        }
+
+        /// <summary>
+        /// Handle the Keycloak authentication redirect to the application when it has specified an error (query parameter)
+        /// </summary>
+        /// <param name="authResult"></param>
+        private void HandleAuthError(AuthorizationResponse authResult)
+        {
+            //If a special Url has been configured to redirect to when an error was returned from Keycloak authentication, redirect the user to that Url with the error information from Keycloak as query parameters
+            if (!string.IsNullOrWhiteSpace(Options.AuthResponseErrorRedirectUrl))
+            {
+                // Build authentication error redirect URL
+                string authResponseErrorRedirectUrl = Options.AuthResponseErrorRedirectUrl;
+                if (Uri.IsWellFormedUriString(authResponseErrorRedirectUrl, UriKind.Relative))
+                {
+                    // Relative address configured. Use the current application root address as parent.
+                    string baseAddress = string.Format("{0}{1}", Request.Uri.GetLeftPart(UriPartial.Authority), Options.VirtualDirectory);
+                    authResponseErrorRedirectUrl = baseAddress + authResponseErrorRedirectUrl;
+                }
+
+                if (!Uri.IsWellFormedUriString(authResponseErrorRedirectUrl, UriKind.RelativeOrAbsolute))
+                    throw new Exception("Invalid AuthResponseErrorRedirectUrl option: Not a valid relative/absolute URL: " + authResponseErrorRedirectUrl);
+
+                // Add query parameters
+                var parameters = new Dictionary<string, string>();
+                if (!string.IsNullOrEmpty(authResult.Error))
+                    parameters.Add("error", authResult.Error);
+                if (!string.IsNullOrEmpty(authResult.ErrorDescription))
+                    parameters.Add("errordescription", authResult.ErrorDescription);
+                if (!string.IsNullOrEmpty(authResult.ErrorUri))
+                    parameters.Add("erroruri", authResult.ErrorUri);
+                var urlEncodedParameters = new FormUrlEncodedContent(parameters);
+                var authErrorQueryString = urlEncodedParameters.ReadAsStringAsync().Result;
+
+                // Build auth error redirect address with error query parameters from Keycloak.
+                var authErrorUri = new Uri(authResponseErrorRedirectUrl + (!string.IsNullOrEmpty(authErrorQueryString) ? "?" + authErrorQueryString : ""));
+
+                Response.Redirect(authErrorUri.ToString());
+            }
+            else
+            {
+                // If configured the response from the authorization endpoint indicated error (query parameter), and AuthResponseErrorRedirectUrl setting is missing, throw an exception.
+                authResult.ThrowIfError();
+            }
+
         }
 
         #endregion

--- a/src/SampleWebApp/Startup.cs
+++ b/src/SampleWebApp/Startup.cs
@@ -38,9 +38,10 @@ namespace SampleWebApp
 				DisableIssuerValidation = false,
 				DisableAudienceValidation = false,
 
-                		// DisableRefreshTokenSignatureValidation = true, // Fix for Keycloak server v4.5
+			    // DisableRefreshTokenSignatureValidation = true, // Fix for Keycloak server v4.5
+			    // AuthResponseErrorRedirectUrl = "/keycloak-authenticaion-error.html", //Redirect (instead of exception) when Keycloak returns error during authentication. Will include "error" query parameter.
 
-				TokenClockSkew = TimeSpan.FromSeconds(2)
+                TokenClockSkew = TimeSpan.FromSeconds(2)
 			});
 		}
 	}


### PR DESCRIPTION
Adds an optional configuration option **AuthResponseErrorRedirectUrl** (which can be an absolute URL or relative path from your application) that defines an URL to redirect to if Keycloak auth fails during login.

If Keycloak server fails during login, it'll redirect back to calling application (that uses this library) with information in query parameter "error" (and optionally "errordescription" and "erroruri").

If the configuration option **AuthResponseErrorRedirectUrl** is set , it will be used to redirect the user to that page. Query parameters "error", "errordescription" and "erroruri" is passed along from Keycloak (if they exist).

_Note: Previous implementation always throwed an ArgumentException if query parameter "error" was returned from Keycloak. If the new configuration option is not used (default), an Exception
still be thrown (but with additional error information from Keycloak)_
