### PR TITLE
FIX: Option to disable all validation of Refresh Token

### DIFF
--- a/src/Keycloak.IdentityModel/Models/Configuration/DefaultKeycloakParameters.cs
+++ b/src/Keycloak.IdentityModel/Models/Configuration/DefaultKeycloakParameters.cs
@@ -144,6 +144,18 @@ namespace Keycloak.IdentityModel.Models.Configuration
         /// </remarks>
         public bool DisableRefreshTokenSignatureValidation { get; set; } = false;
 
+        /// <summary>
+        ///     OPTIONAL.ADV: Disable all validation of Refresh tokens.
+        /// </summary>
+        /// <remarks>
+        ///     - In Keycloak server somewhere between v4.6-4.8, it was decided that the contents of the "aud" claim in Refresh tokens to contain the Keycloak Realm URL instead of the Keycloak ClientId.
+        ///       This lead to an issue with this library that validates the "aud" claim in Refresh tokens to contain the ClientId.
+        ///       Setting this option to true will disable ALL validation of Refresh token (but keep validation for ID/Access token).
+        ///       As the application should not use the contents of the Refresh tokens, only send it back to the Keycloak server (which will validate it), it should be safe to disable it.
+        ///       This option overrides and can be used instead of DisableRefreshTokenSignatureValidation.
+        ///     - Default: false
+        /// </remarks>
+        public bool DisableAllRefreshTokenValidation { get; set; }
 
         /// <summary>
         ///     OPTIONAL: The absolute or relative URL for users to be redirected to if the authorization response from Keycloak indicated unsuccessful authorization (query parameter "error")

--- a/src/Keycloak.IdentityModel/Models/Configuration/IKeycloakSettings.cs
+++ b/src/Keycloak.IdentityModel/Models/Configuration/IKeycloakSettings.cs
@@ -21,7 +21,7 @@ namespace Keycloak.IdentityModel.Models.Configuration
         string CallbackPath { get; }
         string ResponseType { get; }
         bool DisableRefreshTokenSignatureValidation { get; }
+        bool DisableAllRefreshTokenValidation { get; }
         string AuthResponseErrorRedirectUrl { get; }
-
     }
 }

--- a/src/Owin.Security.Keycloak/Configuration/KeycloakAuthenticationOptions.cs
+++ b/src/Owin.Security.Keycloak/Configuration/KeycloakAuthenticationOptions.cs
@@ -206,6 +206,19 @@ namespace Owin.Security.Keycloak
         public bool DisableRefreshTokenSignatureValidation { get; set; } = false;
 
         /// <summary>
+        ///     OPTIONAL.ADV: Disable all validation of Refresh tokens.
+        /// </summary>
+        /// <remarks>
+        ///     - In Keycloak server somewhere between v4.6-4.8, it was decided that the contents of the "aud" claim in Refresh tokens to contain the Keycloak Realm URL instead of the Keycloak ClientId.
+        ///       This lead to an issue with this library that validates the "aud" claim in Refresh tokens to contain the ClientId.
+        ///       Setting this option to true will disable ALL validation of Refresh token (but keep validation for ID/Access token).
+        ///       As the application should not use the contents of the Refresh tokens, only send it back to the Keycloak server (which will validate it), it should be safe to disable it.
+        ///       This option overrides and can be used instead of DisableRefreshTokenSignatureValidation.
+        ///     - Default: false
+        /// </remarks>
+        public bool DisableAllRefreshTokenValidation { get; set; }
+
+        /// <summary>
         ///     OPTIONAL: The absolute or relative URL for users to be redirected to if the authorization response from Keycloak indicated unsuccessful authorization (query parameter "error")
         /// </summary>
         /// <remarks>

--- a/src/SampleWebApp/Startup.cs
+++ b/src/SampleWebApp/Startup.cs
@@ -38,10 +38,12 @@ namespace SampleWebApp
 				DisableIssuerValidation = false,
 				DisableAudienceValidation = false,
 
-			    // DisableRefreshTokenSignatureValidation = true, // Fix for Keycloak server v4.5
-			    // AuthResponseErrorRedirectUrl = "/keycloak-authenticaion-error.html", //Redirect (instead of exception) when Keycloak returns error during authentication. Will include "error" query parameter.
+				// DisableRefreshTokenSignatureValidation = true, // Fix for Keycloak server v4.5
+				// DisableAllRefreshTokenValidation = true, // Fix for Keycloak server v4.6-4.8,  overrides DisableRefreshTokenSignatureValidation. The content of Refresh token was changed. Refresh token should not be used by the client application other than sending it to the Keycloak server to get a new Access token (where Keycloak server will validate it) - therefore validation in client application can be skipped.
 
-                TokenClockSkew = TimeSpan.FromSeconds(2)
+				// AuthResponseErrorRedirectUrl = "/keycloak-authenticaion-error.html", //Redirect (instead of exception) when Keycloak returns error during authentication. Will include "error" query parameter.
+
+				TokenClockSkew = TimeSpan.FromSeconds(2)
 			});
 		}
 	}


### PR DESCRIPTION
Introducing new option `DisableAllRefreshTokenValidation` (default false)
to disable ALL validation on Refresh tokens.

In Keycloak server somewhere between v4.6-4.8, it was decided that
the contents of the "aud" claim in Refresh tokens to contain the
Keycloak Realm URL instead of the Keycloak ClientId.
This lead to an issue with this library that validates the "aud"
claim in Refresh tokens to contain the ClientId.
Setting this option to true will disable ALL validation of Refresh
tokens (but keep validation for ID/Access token).
As the application should not use the contents of the Refresh tokens,
and only send it back to the Keycloak server (which will validate it),
it should be safe to disable it.
This option overrides and can be used instead of
`DisableRefreshTokenSignatureValidation`.