### PR TITLE
add option for ui_localales query param for proper login page localization

### DIFF
--- a/src/Keycloak.IdentityModel/Models/Configuration/DefaultKeycloakParameters.cs
+++ b/src/Keycloak.IdentityModel/Models/Configuration/DefaultKeycloakParameters.cs
@@ -164,6 +164,18 @@ namespace Keycloak.IdentityModel.Models.Configuration
         ///     - Default: If not specified, an exception will be thrown if and error from Keycloak authentication is received.
         /// </remarks>
         public string AuthResponseErrorRedirectUrl { get; set; }
+        /// <summary>
+        /// OPTIONAL: Query param for login page in order to get the desired locale login page, sending ui_locales query parameter
+        /// By default keycloak will server the login page in this priority
+        /// 1. kc_locale query parameter
+        /// 2. KEYCLOAK_LOCALE cookie value
+        /// 3. User’s preferred locale if a user instance is available
+        /// 4. ui_locales query parameter
+        /// 5. Accept-Language request header
+        /// 6. Realm’s default language
+        /// </summary>
+
+        public string UiLocales { get; set; }
 
     }
 }

--- a/src/Keycloak.IdentityModel/Models/Configuration/IKeycloakSettings.cs
+++ b/src/Keycloak.IdentityModel/Models/Configuration/IKeycloakSettings.cs
@@ -23,5 +23,7 @@ namespace Keycloak.IdentityModel.Models.Configuration
         bool DisableRefreshTokenSignatureValidation { get; }
         bool DisableAllRefreshTokenValidation { get; }
         string AuthResponseErrorRedirectUrl { get; }
+
+        string UiLocales { get; set; }
     }
 }

--- a/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
+++ b/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
@@ -278,6 +278,9 @@ namespace Keycloak.IdentityModel.Utilities
             if (!string.IsNullOrWhiteSpace(_options.IdentityProvider))
                 parameters.Add(Constants.KeycloakParameters.IdpHint, _options.IdentityProvider);
 
+            if (!string.IsNullOrWhiteSpace(_options.UiLocales))
+                parameters.Add(Protocols.OpenIdConnectParameterNames.UiLocales, _options.UiLocales);
+
             return new FormUrlEncodedContent(parameters);
         }
 

--- a/src/Owin.Security.Keycloak/Configuration/KeycloakAuthenticationOptions.cs
+++ b/src/Owin.Security.Keycloak/Configuration/KeycloakAuthenticationOptions.cs
@@ -226,5 +226,16 @@ namespace Owin.Security.Keycloak
         /// </remarks>
         public string AuthResponseErrorRedirectUrl { get; set; }
 
+        /// <summary>
+        /// OPTIONAL: Query param for login page in order to get the desired locale login page, sending ui_locales query parameter
+        /// By default keycloak will server the login page in this priority
+        /// 1. kc_locale query parameter
+        /// 2. KEYCLOAK_LOCALE cookie value
+        /// 3. User’s preferred locale if a user instance is available
+        /// 4. ui_locales query parameter
+        /// 5. Accept-Language request header
+        /// 6. Realm’s default language
+        /// </summary>
+        public string UiLocales { get; set; }
     }
 }


### PR DESCRIPTION
Hello, we had the request to retrieve the login page based on the current ui culture set on the application using the adapter,
so we add the option in order to set the desired locale for retrieving the login page. By default keycloack wil render the login page localized based on these conditions:

With internationalization enabled, the locale is resolved in the following priority:

1. kc_locale query parameter
2. KEYCLOAK_LOCALE cookie value
3. User’s preferred locale if a user instance is available
4. ui_locales query parameter
5. Accept-Language request header
6. Realm’s default language

So, our issue was, suppose our application was starting with a defined uiCulture, the login page was rendered base on 5(Accept-Language) header, which many times was different from the defined in the application.

All you need, which is optional, is to configure your adapter with this parameter, e.g 
```
app.UseKeycloakAuthentication(new KeycloakAuthenticationOptions {
....other initialiation config options
 UiLocales = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName
}
```
Be carefull to have your desired ui culture(based on web.config or whatever) before keycloak initialization.
